### PR TITLE
[#11] Change entity in footer from UKCOD to mySociety

### DIFF
--- a/_includes/mysoc_footer.html
+++ b/_includes/mysoc_footer.html
@@ -50,7 +50,7 @@
 
             <div class="col-sm-9">
                 <div class="mysoc-footer__legal">
-                    <p>mySociety Limited is a project of UK Citizens Online Democracy, a registered charity in England and Wales. For full details visit <a href="https://www.mysociety.org?utm_source=whatdotheyknow.com&amp;utm_content=footer+full+legal+details&amp;utm_medium=link&amp;utm_campaign=mysoc_footer">mysociety.org</a>.</p>
+                    <p><a href="https://www.mysociety.org/?utm_source=data.mysociety.org&utm_content=footer+full+legal+details&utm_medium=link&utm_campaign=mysoc_footer">mySociety</a> is a registered charity in England and Wales (1076346) and a limited company (03277032). We provide commercial services through our wholly owned subsidiary <a href="https://www.societyworks.org/?utm_source=data.mysociety.org&utm_content=footer+full+legal+details&utm_medium=link&utm_campaign=mysoc_footer">SocietyWorks Ltd</a> (05798215).</p>
                 </div>
             </div>
 

--- a/_includes/mysoc_footer.html
+++ b/_includes/mysoc_footer.html
@@ -3,7 +3,7 @@
         <div class="row">
 
             <div class="col-sm-5">
-              <h2 class="mysoc-footer__site-name"><a href="https://mysociety.org?utm_source=whatdotheyknow.com&amp;utm_content=footer+logo&amp;utm_medium=link&amp;utm_campaign=mysoc_footer" class="mysoc-footer__org__logo mysoc-footer__org__logo--mysociety">mySociety</a></h2>
+              <h2 class="mysoc-footer__site-name"><a href="https://mysociety.org?utm_source=data.mysociety.org&amp;utm_content=footer+logo&amp;utm_medium=link&amp;utm_campaign=mysoc_footer" class="mysoc-footer__org__logo mysoc-footer__org__logo--mysociety">mySociety</a></h2>
               <div class="mysoc-footer__site-description">
                   <p>
                     mySociety is a not-for-profit social enterprise, based in
@@ -41,7 +41,7 @@
             <div class="col-sm-3">
                 <div class="mysoc-footer__donate">
                     <p>Your donations keep this site and others like it running</p>
-                    <a href="https://mysociety.org/donate?utm_source=research.mysociety.org&amp;utm_content=footer+donate+now&amp;utm_medium=link&amp;utm_campaign=mysoc_footer" class="mysoc-footer__donate__button">Donate now</a>
+                    <a href="https://mysociety.org/donate?utm_source=data.mysociety.org&amp;utm_content=footer+donate+now&amp;utm_medium=link&amp;utm_campaign=mysoc_footer" class="mysoc-footer__donate__button">Donate now</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Relevant issue(s)
Fixes #11 

## What does this do?

This commit changes the legal entity listed in [/_includes/mysoc_footer.html](https://github.com/mysociety/jkan/blob/gh-pages/_includes/mysoc_footer.html) from 'UKCOD' to 'mySociety', and adds reference to SocietyWorks. For consistency, and ease of reference, it is the text from [WTT](https://www.writetothem.com/).

It also makes a minor change to the utm_source of a few of the related links, as they weren't pointing in the right direction.

## Why was this needed?

The name of the legal entity was changed, and this one had been missed. 😃

## Implementation notes

Nothing controversial (hopefully!).

## Screenshots
Original:
![image](https://user-images.githubusercontent.com/249418/178134933-8d607b42-1951-4bd3-93a3-610500384b4d.png)

Changed:
![image](https://user-images.githubusercontent.com/249418/178134976-68d54237-118d-4ef7-96f0-8d313dfae9fa.png)

## Notes to reviewer

N/A